### PR TITLE
Feature/15/회원정보 조회 수정 기능 구현

### DIFF
--- a/src/main/java/helloworld/studytogether/answer/repository/AnswerRepository.java
+++ b/src/main/java/helloworld/studytogether/answer/repository/AnswerRepository.java
@@ -1,9 +1,12 @@
 package helloworld.studytogether.answer.repository;
 
 import helloworld.studytogether.answer.entity.Answer;
+import helloworld.studytogether.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    int countByUser(User user);  // 특정 사용자의 작성한 답변 개수 계산
+    int countByUserAndIsSelectedTrue(User user);  // 특정 사용자의 채택된 답변 개수 계산
 }

--- a/src/main/java/helloworld/studytogether/answer/repository/AnswerRepository.java
+++ b/src/main/java/helloworld/studytogether/answer/repository/AnswerRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
-    int countByUser(User user);  // 특정 사용자의 작성한 답변 개수 계산
-    int countByUserAndIsSelectedTrue(User user);  // 특정 사용자의 채택된 답변 개수 계산
+    int countByUser_UserId(Long userId);  // 특정 사용자의 작성한 답변 개수 계산
+    int countByUser_UserIdAndIsSelectedTrue(Long userId);  // 특정 사용자의 채택된 답변 개수 계산
 }

--- a/src/main/java/helloworld/studytogether/dictionary/entity/Dictionary.java
+++ b/src/main/java/helloworld/studytogether/dictionary/entity/Dictionary.java
@@ -1,4 +1,4 @@
-package helloworld.studytogether.rewards.entity;
+package helloworld.studytogether.dictionary.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/helloworld/studytogether/questions/repository/QuestionRepository.java
+++ b/src/main/java/helloworld/studytogether/questions/repository/QuestionRepository.java
@@ -1,8 +1,9 @@
 package helloworld.studytogether.questions.repository;
 
+import helloworld.studytogether.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import helloworld.studytogether.questions.entity.Question;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-
+    int countByUser(User user);  // 특정 사용자의 작성한 질문 개수 계산
 }

--- a/src/main/java/helloworld/studytogether/questions/repository/QuestionRepository.java
+++ b/src/main/java/helloworld/studytogether/questions/repository/QuestionRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import helloworld.studytogether.questions.entity.Question;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    int countByUser(User user);  // 특정 사용자의 작성한 질문 개수 계산
+    int countByUser_UserId(Long userId);  // 특정 사용자의 작성한 질문 개수 계산
 }

--- a/src/main/java/helloworld/studytogether/rewards/entity/Rewards.java
+++ b/src/main/java/helloworld/studytogether/rewards/entity/Rewards.java
@@ -1,4 +1,4 @@
-package helloworld.studytogether.dictionary.entity;
+package helloworld.studytogether.rewards.entity;
 
 
 import jakarta.persistence.*;

--- a/src/main/java/helloworld/studytogether/user/dto/CountDTO.java
+++ b/src/main/java/helloworld/studytogether/user/dto/CountDTO.java
@@ -1,0 +1,12 @@
+package helloworld.studytogether.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CountDTO {
+    private int questionCount;
+    private int answerCount;
+    private int selectedAnswerCount;
+}

--- a/src/main/java/helloworld/studytogether/user/dto/UserResponseDTO.java
+++ b/src/main/java/helloworld/studytogether/user/dto/UserResponseDTO.java
@@ -13,5 +13,6 @@ public class UserResponseDTO {
   private String email;
   private String nickname;
   private String role;
+  private CountDTO count;
 
 }

--- a/src/main/java/helloworld/studytogether/user/entity/Count.java
+++ b/src/main/java/helloworld/studytogether/user/entity/Count.java
@@ -1,0 +1,30 @@
+package helloworld.studytogether.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "counts")
+public class Count {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int questionCount;  // 작성한 질문 수
+
+    @Column(nullable = false)
+    private int answerCount;    // 작성한 답변 수
+
+    @Column(nullable = false)
+    private int selectedAnswerCount;  // 채택된 답변 수
+}

--- a/src/main/java/helloworld/studytogether/user/entity/User.java
+++ b/src/main/java/helloworld/studytogether/user/entity/User.java
@@ -42,6 +42,13 @@ public class User {
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private RefreshToken refreshToken;
 
+  /**
+   * User 엔티티와 Count 엔티티를 연결
+   */
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL,fetch = FetchType.LAZY)
+//  @JoinColumn(name = "count_id", nullable = false)
+  private Count count;
+
 
   @Column(nullable = true)
   private Date updated_At;

--- a/src/main/java/helloworld/studytogether/user/entity/User.java
+++ b/src/main/java/helloworld/studytogether/user/entity/User.java
@@ -46,7 +46,7 @@ public class User {
    * User 엔티티와 Count 엔티티를 연결
    */
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL,fetch = FetchType.LAZY)
-//  @JoinColumn(name = "count_id", nullable = false)
+  @JoinColumn(name = "count_id", nullable = false)
   private Count count;
 
 

--- a/src/main/java/helloworld/studytogether/user/repository/CountRepository.java
+++ b/src/main/java/helloworld/studytogether/user/repository/CountRepository.java
@@ -1,0 +1,7 @@
+package helloworld.studytogether.user.repository;
+
+import helloworld.studytogether.user.entity.Count;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountRepository extends JpaRepository<Count, Long> {
+}

--- a/src/main/java/helloworld/studytogether/user/service/UserService.java
+++ b/src/main/java/helloworld/studytogether/user/service/UserService.java
@@ -217,9 +217,9 @@ public class UserService {
         .orElseThrow(() -> new RuntimeException("User not found"));
 
     // Count 값은 동적으로 계산하여 반환
-    int questionCount = questionRepository.countByUser(user);
-    int answerCount = answerRepository.countByUser(user);
-    int selectedAnswerCount = answerRepository.countByUserAndIsSelectedTrue(user);
+    int questionCount = questionRepository.countByUser_UserId(user.getUserId());
+    int answerCount = answerRepository.countByUser_UserId(user.getUserId());
+    int selectedAnswerCount = answerRepository.countByUser_UserIdAndIsSelectedTrue(user.getUserId());
 
 
     // UserResponseDTO로 반환
@@ -259,9 +259,9 @@ public class UserService {
     user = userRepository.save(user); // 업데이트된 사용자 정보 저장
 
     // Count 값은 동적으로 계산하여 반환
-    int questionCount = questionRepository.countByUser(user);
-    int answerCount = answerRepository.countByUser(user);
-    int selectedAnswerCount = answerRepository.countByUserAndIsSelectedTrue(user);
+    int questionCount = questionRepository.countByUser_UserId(user.getUserId());
+    int answerCount = answerRepository.countByUser_UserId(user.getUserId());
+    int selectedAnswerCount = answerRepository.countByUser_UserIdAndIsSelectedTrue(user.getUserId());
 
 
 

--- a/src/main/java/helloworld/studytogether/user/service/UserService.java
+++ b/src/main/java/helloworld/studytogether/user/service/UserService.java
@@ -126,17 +126,20 @@
 
 package helloworld.studytogether.user.service;
 
+import helloworld.studytogether.answer.repository.AnswerRepository;
 import helloworld.studytogether.jwt.util.JWTUtil;
+import helloworld.studytogether.questions.repository.QuestionRepository;
 import helloworld.studytogether.token.entity.RefreshToken;
 import helloworld.studytogether.token.repository.RefreshTokenRepository;
-import helloworld.studytogether.user.dto.CustomUserDetails;
-import helloworld.studytogether.user.dto.LoginDTO;
-import helloworld.studytogether.user.dto.UserResponseDTO;
-import helloworld.studytogether.user.dto.UserUpdateDTO;
+import helloworld.studytogether.user.dto.*;
+import helloworld.studytogether.user.entity.Count;
 import helloworld.studytogether.user.entity.Role;
 import helloworld.studytogether.user.entity.User;
+import helloworld.studytogether.user.repository.CountRepository;
 import helloworld.studytogether.user.repository.UserRepository;
 import java.util.Date;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -151,16 +154,24 @@ public class UserService {
   private final BCryptPasswordEncoder passwordEncoder; // 비밀번호 암호화를 위한 인코더 추가
   private final JWTUtil jwtUtil;
   private final RefreshTokenRepository refreshTokenRepository; // 리프레시 토큰 저장소 추가
+  private final QuestionRepository questionRepository;
+  private final AnswerRepository answerRepository;
+  private final CountRepository countRepository;
 
   @Value("${spring.jwt.expiration}")
   private Long jwtExpiration;
 
   public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder,
-      JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
+      JWTUtil jwtUtil, RefreshTokenRepository refreshTokenRepository, QuestionRepository questionRepository,
+                     AnswerRepository answerRepository, CountRepository countRepository) {
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
     this.jwtUtil = jwtUtil;
     this.refreshTokenRepository = refreshTokenRepository;
+    this.questionRepository = questionRepository;
+    this.answerRepository = answerRepository;
+    this.countRepository = countRepository;
+
   }
 
   // 로그인 로직: DB에서 사용자 정보 조회 후 JWT 발급
@@ -194,17 +205,38 @@ public class UserService {
   }
 
   // 사용자 정보 반환
+
+  /**
+   *회원 정보 조회 시 Count 필드 업데이트 및 조회 로직 추가
+   * @return
+   */
+//  @Transactional
   public UserResponseDTO getLoggedInUser() {
     CustomUserDetails userDetails = getLoggedInUserDetails();
     User user = userRepository.findByUserId(userDetails.getUserId())
         .orElseThrow(() -> new RuntimeException("User not found"));
 
+    // Count 값은 동적으로 계산하여 반환
+    int questionCount = questionRepository.countByUser(user);
+    int answerCount = answerRepository.countByUser(user);
+    int selectedAnswerCount = answerRepository.countByUserAndIsSelectedTrue(user);
+
+
+    // UserResponseDTO로 반환
     UserResponseDTO userResponse = new UserResponseDTO();
     //userResponse.setUserId(user.getUserId());
     userResponse.setUsername(user.getUsername());
     userResponse.setEmail(user.getEmail());
     userResponse.setNickname(user.getNickname());
     userResponse.setRole(user.getRole().toString());
+
+    // CountDTO 설정
+    CountDTO countDTO = new CountDTO();
+    countDTO.setQuestionCount(questionCount);
+    countDTO.setAnswerCount(answerCount);
+    countDTO.setSelectedAnswerCount(selectedAnswerCount);
+    userResponse.setCount(countDTO);
+
     return userResponse;
   }
 
@@ -226,6 +258,15 @@ public class UserService {
 
     user = userRepository.save(user); // 업데이트된 사용자 정보 저장
 
+    // Count 값은 동적으로 계산하여 반환
+    int questionCount = questionRepository.countByUser(user);
+    int answerCount = answerRepository.countByUser(user);
+    int selectedAnswerCount = answerRepository.countByUserAndIsSelectedTrue(user);
+
+
+
+
+
     // 업데이트된 정보를 UserResponseDTO로 변환하여 반환
     UserResponseDTO userResponse = new UserResponseDTO();
     //userResponse.setUserId(user.getUserId());
@@ -233,6 +274,14 @@ public class UserService {
     userResponse.setEmail(user.getEmail());
     userResponse.setNickname(user.getNickname());
     userResponse.setRole(user.getRole().toString());
+
+    // CountDTO 설정
+    CountDTO countDTO = new CountDTO();
+    countDTO.setQuestionCount(questionCount);
+    countDTO.setAnswerCount(answerCount);
+    countDTO.setSelectedAnswerCount(selectedAnswerCount);
+    userResponse.setCount(countDTO);
+
     return userResponse;
   }
 


### PR DESCRIPTION
## 추가 사항
- Count 관련 entity / repository / DTO 생성
- 기존 UserService 에 회원정보를 조회/수정되도록 하는 로직 추가

## 변경 사항
- rewardf/dictionary entity 패키지 위치 수정


## 이유
- 패키지 위치가 틀려서

## 테스트 방법
1. Postman을 통해 로그인시 발급된 access token 으로 회원정보 조회되는 것을 확인
2. Postman을 통해 로그인시 발급된 access token 으로 회원정보 수정되는 것을 확인
3. Postman을 통해 로그인시 발급된 access token 으로 수정된 회원 정보가 반환되는 것을 확인
4. Postman을 통해 로그아웃 되는 것을 확인 

## API 테스트 결과 

- [X] 회원정보 조회
<img width="781" alt="회원정보 조회" src="https://github.com/user-attachments/assets/aeeef3c8-a1e1-4df1-8979-cc5f78081947">



- [X] 회원정보 수정
<img width="781" alt="회원정보 수정" src="https://github.com/user-attachments/assets/ed1589e7-4de2-4297-ab0c-ebc76c66cb48">



- [X] 수정된 회원정보 조회 
<img width="781" alt="수정된 회원정보 재조회" src="https://github.com/user-attachments/assets/ec1811aa-e35b-410d-a1d1-dda5e01c0ee4">






## 참고 사항
- 회원정보 조회/수정 api 주소 수정/유지를 두고 의논 필요


close #15


